### PR TITLE
Selectize wait for options

### DIFF
--- a/PyWebRunner/WebRunner.py
+++ b/PyWebRunner/WebRunner.py
@@ -559,7 +559,7 @@ class WebRunner(object):
         if blur:
             elem.send_keys(Keys.TAB)
 
-    def set_selectize(self, selector, value, **kwargs):
+    def set_selectize(self, selector, value, text=None, clear=True, blur=False, **kwargs):
         '''
         Sets visible value of a selectize control based on the "selectized" element.
 
@@ -569,18 +569,46 @@ class WebRunner(object):
             A CSS selector to search for. This can be any valid CSS selector.
 
         value: str
-            The value to fill the selectize input with.
-            (Visible value, not necessarily the same as the stored value.
-             This way, we mimick the user's interaction as closely as possible.)
+            The value of the option to select.
+            (Stored Value)
 
+        text: str
+            The visible value that the user sees.
+            (Visible value, if different than the stored value)
+
+        clear: bool
+            Whether or not we should clear the selectize value first.
+            Defaults to True
+
+        blur: bool
+            Whether or not we should blur the element after setting the value.
+            This corresponds to the 'selectOnTab' selecize setting.
+            Defaults to False
+
+        kwargs:
+            passed on to wait_for_visible
         '''
-        keys_to_send = Keys.BACK_SPACE + value
         selectize_control = selector + ' + .selectize-control'
         selectize_input = selectize_control + ' input'
+
         # Make sure the selectize control is active so the input is visible
         self.click(selectize_control)
+
+        input_element = self.get_element(selectize_input)
+
+        if clear:
+            input_element.send_keys(Keys.BACK_SPACE)
+
+        input_element.send_keys(text or value)
+
+        # Wait for options to be rendered
         self.wait_for_visible(selectize_control + ' .has-options')
-        self.set_value(selectize_input, keys_to_send, clear=False, **kwargs)
+
+        if blur:
+            input_element.send_keys(Keys.TAB)
+        else:
+            # Click the option for the given value
+            self.click(selectize_control + ' .option[data-value="{}"]'.format(value))
 
     def clear(self, selector):
         '''

--- a/PyWebRunner/WebRunner.py
+++ b/PyWebRunner/WebRunner.py
@@ -559,7 +559,7 @@ class WebRunner(object):
         if blur:
             elem.send_keys(Keys.TAB)
 
-    def set_selectize(self, selector, value, text=None, clear=True, blur=False, **kwargs):
+    def set_selectize(self, selector, value, text=None, clear=True, blur=False):
         '''
         Sets visible value of a selectize control based on the "selectized" element.
 
@@ -584,9 +584,6 @@ class WebRunner(object):
             Whether or not we should blur the element after setting the value.
             This corresponds to the 'selectOnTab' selecize setting.
             Defaults to False
-
-        kwargs:
-            passed on to wait_for_visible
         '''
         selectize_control = selector + ' + .selectize-control'
         selectize_input = selectize_control + ' input'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists('README.rst'):
 
 setup(
     name='PyWebRunner',
-    version='1.4.2',
+    version='1.4.3',
     url='http://github.com/IntuitiveWebSolutions/PyWebRunner',
     license='MIT',
     author='Scott Blevins',

--- a/tests/html/selectize.html
+++ b/tests/html/selectize.html
@@ -1,17 +1,30 @@
 <link rel="stylesheet" type="text/css" href="/tests/html/css/selectize.css" />
-<select id="testSelectize">
-    <option>Option 1</option>
-    <option>Option 2</option>
-    <option>Option 3</option>
-    <option>Option 4</option>
-</select>
+<select id="testSelectize"></select>
 
 <script type="text/javascript" src="/tests/html/js/jquery.js"></script>
 <script type="text/javascript" src="/tests/html/js/selectize.js"></script>
 <script type="text/javascript">
     $(function() {
-        $('#testSelectize').selectize({
-            selectOnTab: true
-        });
+        var selectizeConfiguration = {};
+
+        var options = [
+            {value: 'Option 1', text: 'Option 1'},
+            {value: 'Option 2', text: 'Option 2'},
+            {value: 'Option 3', text: 'Option 3'},
+            {value: 'Option 4', text: 'Option 4'}
+        ]
+
+        if (window.location.search.indexOf('async') !== -1) {
+            selectizeConfiguration.load = function(query, callback) {
+                setTimeout(function() {
+                    callback(options);
+                }, 3000);
+            }
+        }
+        else {
+            selectizeConfiguration.options = options;
+        }
+
+        $('#testSelectize').selectize(selectizeConfiguration);
     });
 </script>

--- a/tests/test_selectize.py
+++ b/tests/test_selectize.py
@@ -3,10 +3,18 @@ from HttpBase import HttpBase
 
 class TestSelectize(HttpBase):
 
-    def test_set_selectize(self):
+    def test_set_selectize_basic(self):
         self.wt.goto('/tests/html/selectize.html')
         select_el = '#testSelectize'
         test_value = 'Option 2'
+        self.wt.wait_for_visible(select_el + ' + .selectize-control')
+        self.wt.set_selectize(select_el, test_value)
+        assert self.wt.get_value(select_el) == test_value
+
+    def test_set_selectize_async(self):
+        self.wt.goto('/tests/html/selectize.html?async=true')
+        select_el = '#testSelectize'
+        test_value = 'Option 3'
         self.wt.wait_for_visible(select_el + ' + .selectize-control')
         self.wt.set_selectize(select_el, test_value)
         assert self.wt.get_value(select_el) == test_value


### PR DESCRIPTION
`set_selectize` needs to be able to handle asynchronous option loading.

I updated the function to handle this case with an additional `wait_for`. As a side effect, `set_selectize` is now independent of `set_value`, as I think the control and clarity is better this way.

I added a test for the asynchronous loading. There isn't a precedent for this, but I passed a url parameter to the test page to control the `selectize` configuration and reuse the html for different tests.