### PR TITLE
Capture Screenshot When wait_for Times Out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.8.9] - 2016-09-26
+### Added
+- Introduced ability to take screenshots automatically when a `wait_for` times out.
+
 ## [1.8.8] - 2016-09-16
 ### Changed
 - Added `driver_init_timeout` parameter to control the timeout of instantiating the driver.

--- a/PyWebRunner/WebRunner.py
+++ b/PyWebRunner/WebRunner.py
@@ -105,6 +105,9 @@ class WebRunner(object):
         # Turn off annoying selenium logs
         s_logger.setLevel(logging.WARNING)
 
+        # Conditionally capture screenshot when wait_for times out
+        self.timeout_screenshot_path = kwargs.get('timeout_screenshot_path')
+
     def _before(self):
         pass
 
@@ -1417,10 +1420,12 @@ class WebRunner(object):
             wait = WebDriverWait(self.browser, kwargs.get('timeout') or self.timeout)
             wait.until(wait_function)
         except TimeoutException:
-          if self.driver == 'Gecko':
-              print("Geckodriver can't use the text_to_be_present_in_element_value wait for some reason.")
-          else:
-              raise
+            if self.timeout_screenshot_path:
+                self.screenshot(self.timeout_screenshot_path)
+            if self.driver == 'Gecko':
+                print("Geckodriver can't use the text_to_be_present_in_element_value wait for some reason.")
+            else:
+                raise
 
     def wait_for_alert(self, **kwargs):
         '''

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if os.path.exists('README.rst'):
 
 setup(
     name='PyWebRunner',
-    version='1.8.8',
+    version='1.8.9',
     url='http://github.com/IntuitiveWebSolutions/PyWebRunner',
     license='MIT',
     author='Scott Blevins',


### PR DESCRIPTION
It would help debug failing `wait_for` calls if we could automatically generate a screenshot on timeout, rather than having to scramble to re-create a failure. This adds an option to pass to `WebRunner` that dictates where screenshots for timeout failures should go.