### PR TITLE
Fix wait_for_alert

### DIFF
--- a/PyWebRunner/WebRunner.py
+++ b/PyWebRunner/WebRunner.py
@@ -1655,7 +1655,7 @@ class WebRunner(object):
         Shortcut for waiting for alert. If it not ends with exception, it
         returns that alert.
         '''
-        self._wait_for(self.alert_present, **kwargs)
+        self._wait_for(EC.alert_is_present(), **kwargs)
 
     def wait_for_presence(self, selector='', **kwargs):
         '''

--- a/tests/html/alert.html
+++ b/tests/html/alert.html
@@ -1,0 +1,2 @@
+<button id="instaalert" type="button" onclick="alert('Hello World');">Insta-Alert</button>
+<button id="delayedalert" type="button" onclick="setTimeout(function(){alert('Hellow Slow World')}, 1000);">1s delayed alert</button>

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -29,6 +29,20 @@ class TestMisc(HttpBase):
         assert os.path.isfile(path)
         assert os.path.getsize(path) > 0
 
+    def test_alert(self):
+        self.wt.goto('/tests/html/alert.html')
+        self.wt.click('#instaalert')
+        self.wt.wait_for_alert()
+        assert self.wt.alert_present()
+        self.wt.close_alert()
+
+    def test_delayed_alert(self):
+        self.wt.goto('/tests/html/alert.html')
+        self.wt.click('#delayedalert')
+        self.wt.wait_for_alert()
+        assert self.wt.alert_present()
+        self.wt.close_alert()
+
     # def test_no_js_errors(self):
     #     self.wt.goto('/tests/html/misc.html')
     #     self.wt.assert_js_errors(False)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -43,6 +43,15 @@ class TestMisc(HttpBase):
         assert self.wt.alert_present()
         self.wt.close_alert()
 
+    def test_delayed_alert_short_timeout(self):
+        import pytest
+        from selenium.common.exceptions import TimeoutException
+
+        self.wt.goto('/tests/html/alert.html')
+        self.wt.click('#delayedalert')
+        with pytest.raises(TimeoutException):
+            self.wt.wait_for_alert(timeout=.01)
+
     # def test_no_js_errors(self):
     #     self.wt.goto('/tests/html/misc.html')
     #     self.wt.assert_js_errors(False)


### PR DESCRIPTION
This PR is to fix the issue of wait_for_alert failing when called regardless of operations.

```
self = <selenium.webdriver.support.wait.WebDriverWait (session="8959d396a2f011793f6c32021cfa70c8")>, method = <class 'selenium.webdriver.support.expected_conditions.alert_is_present'>, message = ''

    def until(self, method, message=''):
        """Calls the method provided with the driver as an argument until the \
            return value is not False."""
        screen = None
        stacktrace = None
    
        end_time = time.time() + self._timeout
        while True:
            try:
>               value = method(self._driver)
E               TypeError: __init__() takes 1 positional argument but 2 were given

.venv/lib/python3.5/site-packages/selenium/webdriver/support/wait.py:71: TypeError
```

This PR fixes the above issue and adds a few test cases. Tests can be ran by:
```
 py.test  tests/test_misc.py::TestMisc
```
To handle case where the timeout is shorter than the alert, I needed to import pytest to test that exception. The tests cases look pretty clean so not for sure if that is an issue or not. https://github.com/IntuitiveWebSolutions/PyWebRunner/compare/master...mr337:fix_wait_for_alert?expand=1#diff-ba96ca525f7bacd1a0ee8b10d71d6b2bR47